### PR TITLE
Fix error time value and error/end active check

### DIFF
--- a/src/DeferredSink.js
+++ b/src/DeferredSink.js
@@ -18,22 +18,22 @@ export default class DeferredSink {
     }
 
     if (this.events.length === 0) {
-      defer(new PropagateAllTask(this.sink, this.events))
+      defer(new PropagateAllTask(this.sink, t, this.events))
     }
 
     this.events.push({ time: t, value: x })
   }
 
-  error (t, e) {
+  end (t, x) {
     if (!this.active) {
       return
     }
 
-    this._end(new ErrorTask(t, e, this.sink))
+    this._end(new EndTask(t, x, this.sink))
   }
 
-  end (t, x) {
-    this._end(new EndTask(t, x, this.sink))
+  error (t, e) {
+    this._end(new ErrorTask(t, e, this.sink))
   }
 
   _end (task) {

--- a/src/PropagateAllTask.js
+++ b/src/PropagateAllTask.js
@@ -1,8 +1,9 @@
 /** @license MIT License (c) copyright 2010-2016 original author or authors */
 
 export default class PropagateAllTask {
-  constructor (sink, events) {
+  constructor (sink, time, events) {
     this.sink = sink
+    this.time = time
     this.events = events
   }
 
@@ -13,6 +14,7 @@ export default class PropagateAllTask {
 
     for (let i = 0, l = events.length; i < l; ++i) {
       event = events[i]
+      this.time = event.time
       sink.event(event.time, event.value)
     }
 
@@ -20,6 +22,6 @@ export default class PropagateAllTask {
   }
 
   error (e) {
-    this.sink.error(0, e)
+    this.sink.error(this.time, e)
   }
 }


### PR DESCRIPTION
This change propagates a meaningful time value for errors caused when event propagation throws.  Previously, it was just using `0`.  This also fixes error/end active checking.  Errors should always be allowed to propagate, even after end, so that errors are never hidden.
