### PR TITLE
Update type-definition to be compatible with UMD for default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@most/create",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "create",
   "main": "dist/create.js",
   "typings": "type-definitions/index.d.ts",

--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -19,6 +19,8 @@ declare interface DisposeFn {
   (): void | Promise<any>;
 }
 
-export default function create<A>(f: (add: (a: A) => void,
+declare function create<A>(f: (add: (a: A) => void,
                                       end: (x?: A) => void,
                                       error: (e: Error) => void) => void | DisposeFn ): Stream<A>;
+
+export = create;


### PR DESCRIPTION
When outputting using CommonJS or UMD while using a default export the type-definition needs to use the `export = ...` syntax and not ES6 syntax.
