### PR TITLE
Add compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Imperatively push events into a Stream.
 
-Note: @most/create is compatible `most` 1.x.  It is not compatible with `@most/core`.  In `@most/core`, simply [implement the Stream interface](https://mostcore.readthedocs.io/en/latest/api.html#stream), or use [@most/adapter](https://github.com/mostjs/adapter).
+Note: `@most/create` is compatible `most` 1.x.  It is not compatible with `@most/core`.  In `@most/core`, simply [implement the Stream interface](https://mostcore.readthedocs.io/en/latest/api.html#stream), or use [@most/adapter](https://github.com/mostjs/adapter).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Imperatively push events into a Stream.
 
+Note: @most/create is compatible `most` 1.x.  It is not compatible with `@most/core`.  In `@most/core`, simply [implement the Stream interface](https://mostcore.readthedocs.io/en/latest/api.html#stream), or use [@most/adapter](https://github.com/mostjs/adapter).
+
 ## Install
 
 ```
@@ -104,4 +106,3 @@ If the publisher returns a dispose function, it will be called when the stream e
 * `dispose` - free resources held by the publisher
 
 Note that if the stream neither ends nor fails, the dispose function will never be called.
-


### PR DESCRIPTION
See https://github.com/mostjs/create/pull/14

Add a note to the README to clarify that `@most/create` is only compatible with `most` 1.x, and point to `@most/adapter` and Stream interface for `@most/core`.